### PR TITLE
Smooth virtual joystick PR: Remove unused enum values

### DIFF
--- a/src/gui/touchscreengui.cpp
+++ b/src/gui/touchscreengui.cpp
@@ -52,18 +52,6 @@ static irr::EKEY_CODE id2keycode(touch_gui_button_id id)
 {
 	std::string key = "";
 	switch (id) {
-		case forward_id:
-			key = "forward";
-			break;
-		case left_id:
-			key = "left";
-			break;
-		case right_id:
-			key = "right";
-			break;
-		case backward_id:
-			key = "backward";
-			break;
 		case inventory_id:
 			key = "inventory";
 			break;

--- a/src/gui/touchscreengui.h
+++ b/src/gui/touchscreengui.h
@@ -54,10 +54,6 @@ typedef enum
 	chat_id,
 	inventory_id,
 	drop_id,
-	forward_id,
-	backward_id,
-	left_id,
-	right_id,
 	joystick_off_id,
 	joystick_bg_id,
 	joystick_center_id


### PR DESCRIPTION
These enum values are now unused. If you'd prefer a review comment suggesting changes instead of a PR next time, please tell me.